### PR TITLE
Added support for pre-multiplying the alpha channel to fix halo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.egg-info
 dist
 build
+/.idea
+*.iml
+bin/__init__.py
+bin/aaresize.py

--- a/android_asset_resizer/resizer.py
+++ b/android_asset_resizer/resizer.py
@@ -83,6 +83,12 @@ class AssetResizer():
         # Get the original image size
         w, h = im.size
 
+        if self.premult:
+            im_premultiplied = im.copy()
+            premultiply(im_premultiplied)
+        else:
+            im_premultiplied = im
+
         # Generate assets from the source image
         for d in DENSITY_TYPES:
             if d == 'ldpi' and not self.ldpi:
@@ -99,15 +105,12 @@ class AssetResizer():
                 size = (self.get_size_for_density(w, d),
                         self.get_size_for_density(h, d))
 
-                if self.premult:
-                    premultiply(im)
-
-                im = im.resize(size, self.image_filter)
+                im_resized = im_premultiplied.resize(size, self.image_filter)
 
                 if self.premult:
-                    unmultiply(im)
+                    unmultiply(im_resized)
 
-                im.save(out_file, quality=self.image_quality)
+                im_resized.save(out_file, quality=self.image_quality)
 
 def premultiply(im):
     pixels = im.load()

--- a/android_asset_resizer/resizer.py
+++ b/android_asset_resizer/resizer.py
@@ -15,7 +15,8 @@ DENSITY_MAP = {
 
 class AssetResizer():
     def __init__(self, out, source_density='xhdpi', prefix='', ldpi=False,
-            xxxhdpi=False, image_filter=Image.ANTIALIAS, image_quality=None):
+            xxxhdpi=False, image_filter=Image.ANTIALIAS, image_quality=None,
+            premult=False):
         if source_density not in DENSITY_TYPES:
             raise ValueError('source_density must be one of %s' % str(DENSITY_TYPES))
 
@@ -26,6 +27,7 @@ class AssetResizer():
         self.xxxhdpi = xxxhdpi
         self.image_filter = image_filter
         self.image_quality = image_quality
+        self.premult = premult
 
     def mkres(self):
         """
@@ -96,5 +98,35 @@ class AssetResizer():
             else:
                 size = (self.get_size_for_density(w, d),
                         self.get_size_for_density(h, d))
-                im.resize(size, self.image_filter).save(out_file,
-                        quality=self.image_quality)
+
+                if self.premult:
+                    premultiply(im)
+
+                im = im.resize(size, self.image_filter)
+
+                if self.premult:
+                    unmultiply(im)
+
+                im.save(out_file, quality=self.image_quality)
+
+def premultiply(im):
+    pixels = im.load()
+    for y in range(im.size[1]):
+        for x in range(im.size[0]):
+            r, g, b, a = pixels[x, y]
+            if a != 255:
+                r = r * a // 255
+                g = g * a // 255
+                b = b * a // 255
+                pixels[x, y] = (r, g, b, a)
+
+def unmultiply(im):
+    pixels = im.load()
+    for y in range(im.size[1]):
+        for x in range(im.size[0]):
+            r, g, b, a = pixels[x, y]
+            if a != 255 and a != 0:
+                r = 255 if r >= a else 255 * r // a
+                g = 255 if g >= a else 255 * g // a
+                b = 255 if b >= a else 255 * b // a
+                pixels[x, y] = (r, g, b, a)

--- a/bin/aaresize
+++ b/bin/aaresize
@@ -120,6 +120,9 @@ def main():
             help='disable experimental multiprocessing support and process images serially')
     parser.add_argument('--quiet', action='store_true',
             help='suppress all output except for errors')
+    parser.add_argument('--premult', action='store_true',
+            help='use pre-multiplied alpha to prevent halos around images when using alpha'
+                 ' (a bit slower and very slight loss of fidelity)')
     parser.add_argument('--version', action='version',
             version='%(prog)s {v}'.format(v=__version__))
     parser.add_argument('pattern', nargs='+',
@@ -168,6 +171,7 @@ def main():
     resizer.prefix = args.prefix
     resizer.image_filter = PIL_FILTER_MAP.get(args.filter)
     resizer.image_quality = args.quality
+    resizer.premult = args.premult
 
     # Make our resource directories
     resizer.mkres()


### PR DESCRIPTION
Added a command-line switch to make pre-multiplying optional, since it slows processing down quite a bit
Based on this StackOverflow answer: http://stackoverflow.com/a/13201044/304876

Fix for #15.